### PR TITLE
changing eos_command to eos_config for 2.2 support.  

### DIFF
--- a/eos_module.yml
+++ b/eos_module.yml
@@ -8,7 +8,7 @@
   tasks:
     # Call the eos_command module if module is set to eos_command
     - name: "{{ description | default('command playbook task') }}"
-      eos_command:
+      eos_config:
         commands: "{{ cmds | default(omit) }}"
         auth_pass: "{{ auth_pass | default(omit) }}"
         authorize: "{{ authorize | default(omit) }}"


### PR DESCRIPTION
This is backwards compatible in 2.1 as well.  I have run the BGP role test suite without any issue here.
